### PR TITLE
Stream raw Buffers when encoding is not specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,10 @@ function createReadStream (path, options) {
         if (err) return ds.emit('error', err);
         if (bytesRead) {
           pos += bytesRead;
-          var data = b.slice(0, bytesRead).toString(options.encoding);
+          var data = b.slice(0, bytesRead);
+          if (options.encoding) {
+            data = data.toString(options.encoding);
+          }
           ds.push(data);
           setImmediate(readChunk);
         } else if (reading) {

--- a/test/index.js
+++ b/test/index.js
@@ -135,3 +135,22 @@ it('should be able to stream from a growing file being streamed', function (t) {
   }
   write();
 });
+
+it('should stream Buffer instances when encoding is not set', function (t) {
+  t.plan(3);
+  var ws = fs.createWriteStream(tmpFile, { flags: 'a' });
+  var rs = fst.createReadStream(tmpFile, { tail: true });
+
+  rs.on('data', function (chunk) {
+    t.ok(Buffer.isBuffer(chunk));
+  });
+
+  rs.on('sync', function () {
+    setImmediate(function () {
+      ws.write('test2\n', function (err) {
+        t.ifError(err);
+        rs.close();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Hi :wave: Thanks for publishing this module! :bowing_woman: 

This patch aligns `fs-tail-stream` with the `fs.createReadStream()` behaviour where it only streams Buffer instances when `encoding` is not specified. Previously, this module would call `.toString(options.encoding)` on all new data. It was always pushing strings after the first chunk, even when `encoding: null` was set. With this patch it only calls `toString()` if an encoding was specified.

Thanks!